### PR TITLE
ホーム画面のデザインを改善

### DIFF
--- a/nakajimap/src/App.css
+++ b/nakajimap/src/App.css
@@ -1,33 +1,85 @@
+/* Webkitブラウザ用のスクロールバースタイル */
+::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+}
+::-webkit-scrollbar-track {
+  background-color: #eee; /* スクロールバーエリアの色 */
+}
+::-webkit-scrollbar-thumb {
+  background-color: #aaa; /* スクロールバーの色 */
+  border-radius: 3px; /* 角を丸める */
+}
+
+/* ページ全体の設定 */
+html,
+body {
+  background-color: #fffbf6;
+  zoom: 0.95; /* ホーム画面がデカすぎたため縮小 */
+  margin: 0px;
+}
+
+/* ページ上部の固定ヘッダー */
+.sticky-header {
+  position: fixed;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  height: 100px;
+  width: 100%;
+  background-color: #ddd;
+  border-bottom: 4px solid #666;
+}
+
+/* 画面全体のスタイル */
 .container {
   display: flex;
-  flex-direction: column;
+  flex-direction: column; /* 垂直配置 */
   align-items: center; /* 上下中央揃え */
   justify-content: center; /* 左右中央揃え */
-  height: 98vh; /* ビューポートの高さに合わせる */
-  min-width: 1200px;
-  /* order: 1px solid #000; /* 黒い枠線を追加 (確認用) */
+  min-width: 1260px; /* 拡大時の.contentはみ出しを防ぐ用 */
+  margin-top: 120px; /* ヘッダーの下にコンテンツを配置 */
 }
 
+/* 画面内に垂直配置するコンテンツの基本スタイル */
 .content {
+  width: 1200px; /* これを基準に横幅を揃える */
+  margin: 20px;
+  border: 3px solid #889;
+  border-radius: 6px;
+}
+
+.filter {
+  margin: 30px;
+}
+
+.result-title {
+  color: #57b;
+  margin-left: 30px;
+}
+
+.result-items {
   display: flex;
-  align-items: center; /* 上下中央揃え */
-  justify-content: space-between; /* 左右中央揃え */
-  padding: 10px; /* 内側の余白を追加 */
-  margin: 10px; /* 外側の余白を追加 */
-  border: 1px solid #000; /* 黒い枠線を追加 */
-}
-
-.search-result {
-  flex: 1;
-  margin: 10px;
-  margin-right: 20px;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between; /* 左右両端揃え */
+  width: 1140px;
+  margin: 30px;
   margin-top: 0px;
-  /*border: 1px solid #000; /* 黒い枠線を追加 (確認用) */
 }
 
-.map {
-  /* Mapで定義した幅は400px */
-  flex: 1;
-  margin: 10px;
-  border: 1px solid #000; /* 黒い枠線を追加 */
+.result-table {
+  height: 420px;
+  width: 680px;
+  border: 1px solid #aaa;
+}
+
+.result-map {
+  aspect-ratio: 1 / 1;
+  height: 420px;
+  width: 420px;
+  border: 1px solid #aaa;
 }

--- a/nakajimap/src/App.tsx
+++ b/nakajimap/src/App.tsx
@@ -6,18 +6,28 @@ import { Auth } from "./components/Auth"
 
 function App() {
   return (
-    <div className="container">
-      {/* <Auth /> */}
-      <div className="content">
-        <Filtering />
+    <div>
+      <div className="sticky-header">
+        <h1>ここにロゴ・サイト名・ハンバーガーを配置する</h1>
       </div>
-      <div className="content">
-        <div className="search-result">
-          <h2>検索結果</h2>
-          <SearchResult />
+      <div className="container">
+        <div className="content">
+          <div className="filter">
+            <Filtering />
+          </div>
         </div>
-        <div className="map">
-          <Map />
+        <div className="content">
+          <div className="result-title">
+            <h2>検索結果</h2>
+          </div>
+          <div className="result-items">
+            <div className="result-table">
+              <SearchResult />
+            </div>
+            <div className="result-map">
+              <Map />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/nakajimap/src/components/Filtering.tsx
+++ b/nakajimap/src/components/Filtering.tsx
@@ -30,7 +30,7 @@ const RestaurantFilter: React.FC = () => {
   }
 
   return (
-    <Box sx={{ width: 1103, margin: "normal" }}>
+    <Box sx={{ margin: "normal" }}>
       <Box sx={{ display: "flex", alignItems: "center", gap: 3 }}>
         <TextField
           label="エリア・駅"
@@ -39,6 +39,7 @@ const RestaurantFilter: React.FC = () => {
           fullWidth
           margin="normal"
           placeholder="例: 東京駅"
+          style={{ backgroundColor: "#fcfcfc" }}
         />
         <Typography sx={{ whiteSpace: "nowrap" }}>周辺</Typography>
         <TextField
@@ -50,6 +51,7 @@ const RestaurantFilter: React.FC = () => {
           margin="normal"
           placeholder="800"
           inputProps={{ step: 100, min: 100 }}
+          style={{ backgroundColor: "#fcfcfc" }}
         />
         <Typography sx={{ whiteSpace: "nowrap" }}>m以内</Typography>
       </Box>
@@ -61,6 +63,7 @@ const RestaurantFilter: React.FC = () => {
           fullWidth
           margin="normal"
           placeholder="例: 和食"
+          style={{ backgroundColor: "#fcfcfc" }}
         />
         <Typography sx={{ whiteSpace: "nowrap" }}>¥</Typography>
         <TextField
@@ -70,6 +73,7 @@ const RestaurantFilter: React.FC = () => {
           onChange={(e) => setMinBudget(e.target.value)}
           inputProps={{ step: 500, min: 0 }}
           placeholder="1000"
+          style={{ backgroundColor: "#fcfcfc" }}
         />
         <Typography sx={{ whiteSpace: "nowrap" }}>~</Typography>
         <TextField
@@ -79,6 +83,7 @@ const RestaurantFilter: React.FC = () => {
           onChange={(e) => setMaxBudget(e.target.value)}
           inputProps={{ step: 500, min: 0 }}
           placeholder="3000"
+          style={{ backgroundColor: "#fcfcfc" }}
         />
       </Box>
       <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
@@ -90,6 +95,7 @@ const RestaurantFilter: React.FC = () => {
           fullWidth
           margin="normal"
           inputProps={{ step: 10, min: 0 }}
+          style={{ backgroundColor: "#fcfcfc" }}
         />
         <TextField
           label="☆評価の数はいくつ以上か"
@@ -99,6 +105,7 @@ const RestaurantFilter: React.FC = () => {
           fullWidth
           margin="normal"
           inputProps={{ step: 0.5, min: 0 }}
+          style={{ backgroundColor: "#fcfcfc" }}
         />
       </Box>
       <Box mt={3} sx={{ display: "flex", justifyContent: "flex-end" }}>
@@ -106,7 +113,7 @@ const RestaurantFilter: React.FC = () => {
           検索
         </Button>
       </Box>
-      <Box mt={4}>
+      {/* <Box mt={4} style={{zoom: 0.8}}>
         <Typography variant="h6">入力された条件:</Typography>
         <Typography>場所: {filters.location}</Typography>
         <Typography>距離: {filters.distance} m以内</Typography>
@@ -116,7 +123,7 @@ const RestaurantFilter: React.FC = () => {
         <Typography>料理のジャンル: {filters.cuisine}</Typography>
         <Typography>口コミ数: {filters.reviewCount} 件以上</Typography>
         <Typography>☆評価: {filters.rating} 以上</Typography>
-      </Box>
+      </Box> */}
     </Box>
   )
 }

--- a/nakajimap/src/components/Map.tsx
+++ b/nakajimap/src/components/Map.tsx
@@ -51,7 +51,7 @@ const Map: React.FC = () => {
     }
   }, [])
 
-  return <div id="map" style={{ height: "433px", width: "434px" }} />
+  return <div id="map" style={{ width: "100%", height: "100%" }} />
 }
 
 export default Map

--- a/nakajimap/src/components/Table.tsx
+++ b/nakajimap/src/components/Table.tsx
@@ -71,30 +71,37 @@ export default function SearchResult() {
   })
 
   return (
-    <TableContainer component={Paper} style={{ maxHeight: 366, overflow: "auto" }}>
-      <Table stickyHeader style={{ width: 600 }} size="small" aria-label="simple table">
+    <TableContainer
+      component={Paper}
+      style={{ height: "100%", overflowX: "hidden", overflowY: "auto", backgroundColor: "#fcfcfc" }}
+    >
+      <Table stickyHeader size="small" aria-label="simple table">
         <TableHead>
           <TableRow>
-            <TableCell align="left">
+            <TableCell align="left" style={{ backgroundColor: "#eaeafa" }}>
               <TableSortLabel
                 active={orderBy === "star"}
                 direction={order === "desc" ? "desc" : "desc"}
                 onClick={() => handleSortRequest("star")}
               >
-                評価
+                ☆評価
               </TableSortLabel>
             </TableCell>
-            <TableCell align="left">
+            <TableCell align="left" style={{ backgroundColor: "#eaeafa" }}>
               <TableSortLabel
                 active={orderBy === "n_review"}
                 direction={order === "desc" ? "desc" : "desc"}
                 onClick={() => handleSortRequest("n_review")}
               >
-                口コミ件数
+                口コミ数
               </TableSortLabel>
             </TableCell>
-            <TableCell align="left">店名</TableCell>
-            <TableCell align="left">行きたい</TableCell>
+            <TableCell align="left" style={{ backgroundColor: "#eaeafa" }}>
+              店名
+            </TableCell>
+            <TableCell align="left" style={{ backgroundColor: "#eaeafa" }}>
+              行きたい
+            </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>


### PR DESCRIPTION
# 概要
- ブラウザや倍率の違いで簡単に体裁が崩れていたので、CSS等を見直して安定できれいなデザインに変更。

# 変更内容
- nakajimap/src/App.css
  - スタイリングはなるべくCSSでやった方が良いと気が付いた。
  - 例えばコンポーネントでサイズを指定すると、再利用性が低くなる。
  - 画面とCSSをにらめっこしながら調整できるのがお手軽。
  - 細かいことはFiles changedにコメントを書くので見て。
- nakajimap/src/App.tsx
  - CSSのクラスに合わせて変更。
  - divタグだらけになるのはそういうものなのか？
- nakajimap/src/components/Filtering.tsx
  - サイズ指定を排除。
  - テキストエリアを若干灰色にした。
  - 出力確認用のTypographyは非表示にしたので、必要に応じてコメントインしてください。 @norosen63 
- nakajimap/src/components/Map.tsx
  - サイズ指定を排除。
  - CSSでzoom倍率を変えれば、同じ表示エリアでもサイズ自体は変更が可能。bodyクラスでzoom調整している。
- nakajimap/src/components/Table.tsx
  - サイズ指定を排除。
  - テーブルの塗りつぶしを変更。列ラベルのセルはCSSで色指定できなかった。
 
# 動作確認

## 確認事項
- `docker-compose up` して ホーム画面にが下記レイアウトで表示されること
![image](https://github.com/sunfish256/nakajimap/assets/84883098/fbb2258a-4e66-4f8d-b039-d742822491c2)

## 確認手順
0. `docker-compose down`  # docker-compose up していた場合のみ
1. `docker builder prune -f`  # ビルドキャッシュを削除
2. `docker rm nakajimap-app-1`  # コンテナを削除
3. `docker rmi nakajimap-app`  # コンテナイメージを削除
4. `docker-compose up`  # コンテナを起動
5. http://localhost:3000/ にアクセス

#  課題
- 上部固定ヘッダーは結構てきとーなので随時改変してください。
