### PR TITLE
お気に入りフィルタ条件の保存機能を実装

### DIFF
--- a/nakajimap/src/components/Filtering.tsx
+++ b/nakajimap/src/components/Filtering.tsx
@@ -2,11 +2,10 @@ import React, { useState, useEffect } from "react"
 import { Box, TextField, Typography, Button, MenuItem, Select } from "@mui/material"
 import { collection, addDoc, getDocs } from "firebase/firestore"
 import { db } from "../firebase"
-import { Box, TextField, Typography, Button } from "@mui/material"
 import { auth } from "../firebase"
 import { useNavigate } from "react-router-dom"
 
-export const RestaurantFilter: React.FC = () => {
+const RestaurantFilter: React.FC = () => {
   const [currentUser, setCurrentUser] = useState<null | object>(null)
   const navigate = useNavigate()
 
@@ -20,7 +19,7 @@ export const RestaurantFilter: React.FC = () => {
     })
     return () => unsubscribe()
   }, [navigate])
-  
+
   const [location, setLocation] = useState("")
   const [distance, setDistance] = useState<string>("")
   const [minBudget, setMinBudget] = useState<string>("")
@@ -232,3 +231,5 @@ export const RestaurantFilter: React.FC = () => {
     </Box>
   )
 }
+
+export default RestaurantFilter

--- a/nakajimap/src/pages/Home.tsx
+++ b/nakajimap/src/pages/Home.tsx
@@ -1,6 +1,6 @@
-import Filtering from '../components/Filtering'
-import Map from '../components/Map'
-import SearchResult from '../components/Table'
+import RestaurantFilter from "../components/Filtering"
+import Map from "../components/Map"
+import SearchResult from "../components/Table"
 import "../Home.css"
 
 const Home: React.FC = () => {
@@ -12,7 +12,7 @@ const Home: React.FC = () => {
       <div className="container">
         <div className="content">
           <div className="filter">
-            <Filtering />
+            <RestaurantFilter />
           </div>
         </div>
         <div className="content">
@@ -31,6 +31,6 @@ const Home: React.FC = () => {
       </div>
     </div>
   )
-  }
+}
 
 export default Home


### PR DESCRIPTION
# 概要
- 「保存」ボタンを押すと、お気に入りフィルタ条件をFirestore上に保存する機能の実装

# 変更内容
- Filtering.tsx に以下のコンポーネントを追加
- 保存ボタン（Button）
- お気に入りフィルタを選択（Typography）
- 選択メニュー（Select）

# 動作確認（任意）

## 確認事項
- 開いてすぐの状態で、選択メニューにお気に入りフィルタ条件が読み込まれている
- フィルタリング条件を入力して保存ボタンを押すと、選択メニューにその条件が追加される

## 確認手順
1. 開いてすぐに選択メニューをクリック→お気に入りフィルタ条件が表示されればOK
2. 適当に条件をいれて保存ボタンを押す→それが追加されていればOK
