### PR TITLE
検索結果の表への反映＋マップピンウィンドウの店舗情報拡充

### DIFF
--- a/nakajimap/src/components/Map.tsx
+++ b/nakajimap/src/components/Map.tsx
@@ -23,44 +23,6 @@ const Map: React.FC<MapProps> = ({ results }) => {
         center: { lat: 35.681236, lng: 139.767125 }, // 東京駅の座標
         zoom: 15, // ズームレベルを調整
       })
-
-      // KITTE丸の内の座標
-      const kitteMarunouchi = { lat: 35.679575, lng: 139.764603 }
-
-      // KITTE丸の内にマーカーを追加
-      const marker = new google.maps.Marker({
-        position: kitteMarunouchi,
-        map: mapInstanceRef.current,
-        title: "KITTE Marunouchi",
-      })
-
-      // 情報ウィンドウのコンテンツ
-      const infoWindowContent = `
-        <div>
-          <h2>KITTE Marunouchi</h2>
-          <p>KITTE Marunouchi is a shopping and dining complex located near Tokyo Station.</p>
-        </div>
-      `
-
-      // 情報ウィンドウを作成
-      const infoWindow = new google.maps.InfoWindow({
-        content: infoWindowContent,
-      })
-
-      // マーカーがクリックされた時のイベントリスナーを追加
-      marker.addListener("click", () => {
-        // 既存の情報ウィンドウがある場合は閉じる
-        if (currentInfoWindowRef.current) {
-          currentInfoWindowRef.current.close()
-        }
-
-        // 新しい情報ウィンドウを開く
-        infoWindow.open(mapInstanceRef.current, marker)
-        // 現在の情報ウィンドウを更新
-        currentInfoWindowRef.current = infoWindow
-      })
-
-      setMarkers([marker])
     }
   }
 
@@ -76,17 +38,23 @@ const Map: React.FC<MapProps> = ({ results }) => {
   useEffect(() => {
     if (mapInstanceRef.current) {
       // 既存のマーカーを全て削除
-      markers.forEach(marker => marker.setMap(null))
+      markers.forEach((marker) => marker.setMap(null))
       setMarkers([])
 
       const newMarkers: google.maps.Marker[] = []
 
       results.forEach((result) => {
         // console.log(result)
-        const lat = typeof result.geometry.location.lat === 'function' ? result.geometry.location.lat() : result.geometry.location.lat
-        const lng = typeof result.geometry.location.lng === 'function' ? result.geometry.location.lng() : result.geometry.location.lng        
+        const lat =
+          typeof result.geometry.location.lat === "function"
+            ? result.geometry.location.lat()
+            : result.geometry.location.lat
+        const lng =
+          typeof result.geometry.location.lng === "function"
+            ? result.geometry.location.lng()
+            : result.geometry.location.lng
 
-        if (typeof lat === 'number' && typeof lng === 'number') {
+        if (typeof lat === "number" && typeof lng === "number") {
           const marker = new google.maps.Marker({
             position: { lat, lng },
             map: mapInstanceRef.current,
@@ -95,8 +63,12 @@ const Map: React.FC<MapProps> = ({ results }) => {
 
           const infoWindowContent = `
             <div>
-              <h2>${result.name}</h2>
+              <p style="font-weight: bold; font-size: 1.2em;">${result.name}</p>
               <p>${result.vicinity}</p>
+              <p>評価: ${result.rating}</p>
+              <p>口コミ数: ${result.user_ratings_total}</p>
+              <p><a href="https://www.google.com/maps/place/?q=place_id:${result.place_id}" target="_blank">
+              グーグルマップで見る</a></p>
             </div>
           `
 
@@ -113,13 +85,13 @@ const Map: React.FC<MapProps> = ({ results }) => {
             // 新しい情報ウィンドウを開く
             infoWindow.open(mapInstanceRef.current, marker)
             // 現在の情報ウィンドウを更新
-            currentInfoWindowRef.current = infoWindow           
+            currentInfoWindowRef.current = infoWindow
           })
 
-          newMarkers.push(marker)                      
+          newMarkers.push(marker)
         } else {
-          console.error('Invalid lat or lng value:', lat, lng)
-        }          
+          console.error("Invalid lat or lng value:", lat, lng)
+        }
       })
 
       // マーカーの配列を更新
@@ -131,11 +103,11 @@ const Map: React.FC<MapProps> = ({ results }) => {
         if (lastMarkerPosition) {
           mapInstanceRef.current.setCenter(lastMarkerPosition)
         }
-      }      
+      }
     }
   }, [results])
 
-  return <div ref={mapRef} id="map" style={{ width: '100%', height: '100%' }} />
+  return <div ref={mapRef} id="map" style={{ width: "100%", height: "100%" }} />
 }
 
 export default Map

--- a/nakajimap/src/components/Table.tsx
+++ b/nakajimap/src/components/Table.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { styled } from "@mui/material/styles"
 import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder"
 import BookmarkIcon from "@mui/icons-material/Bookmark"
@@ -13,35 +13,28 @@ import TableRow from "@mui/material/TableRow"
 import TableSortLabel from "@mui/material/TableSortLabel"
 
 interface TableProps {
-  results: any[];
+  results: any[]
 }
 
 function createData(star: number, n_review: number, shop: string, bookmark: boolean) {
   return { star, n_review, shop, bookmark }
 }
 
-const initialRows = [
-  createData(4.5, 14, "AAAAAAAAAAAAAAAAAA", false),
-  createData(4.0, 237, "BBBBBBBBBBBBBB", false),
-  createData(4.5, 262, "CCCCCCCCCCCCCC", true),
-  createData(3.5, 305, "DDDDDDDDDDDDDDDDDDDDDD", false),
-  createData(4.0, 356, "EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE", true),
-  createData(4.2, 120, "FFFFFFFFFFFFFFFFFFFF", true),
-  createData(3.8, 210, "GGGGGGGGGGGGGGGGGGGGG", false),
-  createData(4.6, 190, "HHHHHHHHHHHHHHHHHHHHHH", false),
-  createData(3.9, 280, "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII", false),
-  createData(4.1, 150, "JJJJJJJJJJJJJJJJJJJJ", false),
-  createData(3.7, 280, "KKKKKKKKKKKKKKKKKKKKKK", false),
-  createData(4.3, 220, "LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLL", true),
-  createData(3.6, 330, "MMMMMMMMMMMMMMMMMMMMMMMM", false),
-  createData(4.4, 180, "NNNNNNNNNNNNNNNNNNNNNNNNNN", true),
-  createData(3.8, 280, "OOOOOOOOOOOOOOOOOOOOOOOOO", false),
-]
+const ScrollableTableCell = styled(TableCell)({
+  maxWidth: "240px",
+  overflowX: "auto",
+  whiteSpace: "nowrap",
+})
 
-export default function SearchResult() {
-  const [rows, setRows] = useState(initialRows)
+const SearchResult: React.FC<TableProps> = ({ results }) => {
+  const [rows, setRows] = useState(results)
   const [order, setOrder] = useState<"desc" | null>(null)
   const [orderBy, setOrderBy] = useState<string | null>(null)
+
+  useEffect(() => {
+    const newRows = results.map((result) => createData(result.rating, result.user_ratings_total, result.name, false))
+    setRows(newRows)
+  }, [results])
 
   const handleSortRequest = (property: string) => {
     if (orderBy === property && order === "desc") {
@@ -67,12 +60,6 @@ export default function SearchResult() {
         return 0
       })
     : rows
-
-  const ScrollableTableCell = styled(TableCell)({
-    maxWidth: "240px",
-    overflowX: "auto",
-    whiteSpace: "nowrap",
-  })
 
   return (
     <TableContainer
@@ -131,3 +118,5 @@ export default function SearchResult() {
     </TableContainer>
   )
 }
+
+export default SearchResult

--- a/nakajimap/src/pages/Home.tsx
+++ b/nakajimap/src/pages/Home.tsx
@@ -15,7 +15,7 @@ const Home: React.FC = () => {
       <div className="container">
         <div className="content">
           <div className="filter">
-            <RestaurantFilter setResults={setResults}/>
+            <RestaurantFilter setResults={setResults} />
           </div>
         </div>
         <div className="content">
@@ -24,10 +24,10 @@ const Home: React.FC = () => {
           </div>
           <div className="result-items">
             <div className="result-table">
-              <SearchResult rows={results}/>
+              <SearchResult results={results} />
             </div>
             <div className="result-map">
-              <Map results={results}/>
+              <Map results={results} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
# 概要

- [レスポンスを検索結果テーブルに受け渡し](https://nakajimap.atlassian.net/browse/NM-77)
- [検索結果の表示(ロジック込)](https://nakajimap.atlassian.net/browse/NM-53)
- [掲載する店舗情報の拡充](https://nakajimap.atlassian.net/browse/NM-82)

# 変更内容

- nakajimap/src/components/Map.tsx
  - 確認用の初期ピン（KITTE丸の内）を削除
  - infoWindowContentに店名、住所、評価、口コミ数、GoogleMapリンクの情報を表示
- nakajimap/src/components/Table.tsx
  - 確認用の表の初期値を削除
  - NearbySearchのレスポンス(results)が渡されたら、それを読み込んで表を更新するロジックを実装
- nakajimap/src/pages/Home.tsx
  - SearchResultsの引数をresultsに変更

# 動作確認（任意）

## 確認事項

- 初期状態で表が空欄、ピンがないこと
- 検索結果（エリア、半径が少なくとも必要）が表、マップに反映されること
- マップピンクリック時に、店名、住所、評価、口コミ数、GoogleMapリンクの情報が表示されること
- 上記リンクが正しいこと

## 確認手順

1. 下記を1行ずつ実行
```
git fetch -p
git checkout feat-result
cd nakajimap
npm install
cd ..
docker-compose down --rmi all
docker builder prune -f
docker-compose up
```
2. http://localhost:3000 にアクセス

#  課題

- 表の行（またはその行の店名）をクリックした時にピン情報のウィンドウが連動して表示される機能がないと使いづらい。
- 検索結果の位置情報を加味したマップ倍率、中心位置のマップが表示されるとよい。