### PR TITLE
マップピンの店舗情報に営業中かを記載

### DIFF
--- a/nakajimap/src/components/Map.tsx
+++ b/nakajimap/src/components/Map.tsx
@@ -62,12 +62,20 @@ const Map: React.FC<MapProps> = ({ results }) => {
             title: result.name,
           })
 
+          const statusText =
+            result.business_status === "OPERATIONAL"
+              ? "営業中"
+              : result.business_status === "CLOSED_TEMPORARILY"
+              ? "営業時間外"
+              : result.business_status === "CLOSED_PERMANENTLY"
+              ? "閉店"
+              : ""
+
           const infoWindowContent = `
             <div>
               <p style="font-weight: bold; font-size: 1.2em;">${result.name}</p>
               <p>${result.vicinity}</p>
-              <p>評価: ${result.rating}</p>
-              <p>口コミ数: ${result.user_ratings_total}</p>
+              <p>評価：${result.rating}　口コミ数：${result.user_ratings_total}　${statusText}</p>
               <p><a href="https://www.google.com/maps/place/?q=place_id:${result.place_id}" target="_blank">
               グーグルマップで見る</a></p>
             </div>


### PR DESCRIPTION
# 概要

- マップピン情報の[掲載する店舗情報の拡充(営業中かどうかも)](https://nakajimap.atlassian.net/browse/NM-82)に対応

# 変更内容

- 営業情報の追加
- 評価、口コミ数、営業情報を1行で表示：縦に長いとスクロールが必要でUXがよくないため

# 動作確認

## 確認事項

- 任意の検索をしてマップピンをクリックし、変更内容の反映を確認

## 確認手順

省略