### PR TITLE
表の店名とマップピン表示のクリック連動を実装

### DIFF
--- a/nakajimap/src/components/Table.tsx
+++ b/nakajimap/src/components/Table.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React, { useState, useEffect } from "react"
 import { styled } from "@mui/material/styles"
 import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder"
 import BookmarkIcon from "@mui/icons-material/Bookmark"
@@ -14,10 +14,11 @@ import TableSortLabel from "@mui/material/TableSortLabel"
 
 interface TableProps {
   results: any[]
+  onShopClick: (placeId: string) => void
 }
 
-function createData(star: number, n_review: number, shop: string, bookmark: boolean) {
-  return { star, n_review, shop, bookmark }
+function createData(star: number, n_review: number, shop: string, bookmark: boolean, placeId: string) {
+  return { star, n_review, shop, bookmark, placeId }
 }
 
 const ScrollableTableCell = styled(TableCell)({
@@ -26,13 +27,15 @@ const ScrollableTableCell = styled(TableCell)({
   whiteSpace: "nowrap",
 })
 
-const SearchResult: React.FC<TableProps> = ({ results }) => {
+const SearchResult: React.FC<TableProps> = ({ results, onShopClick }) => {
   const [rows, setRows] = useState(results)
   const [order, setOrder] = useState<"desc" | null>(null)
   const [orderBy, setOrderBy] = useState<string | null>(null)
 
   useEffect(() => {
-    const newRows = results.map((result) => createData(result.rating, result.user_ratings_total, result.name, false))
+    const newRows = results.map((result) =>
+      createData(result.rating, result.user_ratings_total, result.name, false, result.place_id)
+    )
     setRows(newRows)
   }, [results])
 
@@ -102,7 +105,11 @@ const SearchResult: React.FC<TableProps> = ({ results }) => {
                 {row.star}
               </TableCell>
               <TableCell align="left">{row.n_review}</TableCell>
-              <ScrollableTableCell align="left">{row.shop}</ScrollableTableCell>
+              <ScrollableTableCell align="left" onClick={() => onShopClick(row.placeId)}>
+                <span style={{ color: 'blue', textDecoration: 'underline', cursor: 'pointer' }}>
+                  {row.shop}
+                </span>
+              </ScrollableTableCell>
               <TableCell align="left">
                 <Checkbox
                   icon={<BookmarkBorderIcon />}

--- a/nakajimap/src/pages/Home.tsx
+++ b/nakajimap/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState, useRef } from "react"
 import RestaurantFilter from "../components/Filter"
 import Map from "../components/Map"
 import SearchResult from "../components/Table"
@@ -6,6 +6,13 @@ import "../css/common.css"
 
 const Home: React.FC = () => {
   const [results, setResults] = useState<any[]>([])
+  const mapRef = useRef<{ openInfoWindow: (placeId: string) => void }>(null)
+
+  const handleShopClick = (placeId: string) => {
+    if (mapRef.current) {
+      mapRef.current.openInfoWindow(placeId)
+    }
+  }
 
   return (
     <div>
@@ -21,10 +28,10 @@ const Home: React.FC = () => {
           </div>
           <div className="result-items">
             <div className="result-table">
-              <SearchResult results={results} />
+              <SearchResult results={results} onShopClick={handleShopClick} />
             </div>
             <div className="result-map">
-              <Map results={results} />
+              <Map ref={mapRef} results={results} onMarkerClick={handleShopClick} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
# 概要

- [表とマップピン表示のクリック連動](https://nakajimap.atlassian.net/browse/NM-85)に対応

# 変更内容

- Map.tsxで、openInfoWindow(placeId: string)でピン情報の表示状態を管理する。
- Table.tsxで、店名のonClick動作を定義。上記placeIdを更新する。
- Home.tsxは、上記2点を反映。

# 動作確認

## 確認事項

- 任意の検索結果で表の店名をクリック。該当店舗のマップピンが表示されることを確認する。

## 確認手順

省略。
