### PR TITLE
お気に入り条件のエラー解消

### DIFF
--- a/nakajimap/src/components/Filter.tsx
+++ b/nakajimap/src/components/Filter.tsx
@@ -46,7 +46,7 @@ const RestaurantFilter: React.FC<FilterProps> = ({ setResults }) => {
   const [searchTriggered, setSearchTriggered] = useState(false)
 
   const priceLevels = [
-    { label: "指定なし", p_level: 0 },
+    { label: "指定なし", p_level: undefined },
     { label: "￥", p_level: 1 },
     { label: "￥￥", p_level: 2 },
     { label: "￥￥￥", p_level: 3 },


### PR DESCRIPTION
# 概要
以下3点のバグ解消
1. お気に入りフィルタの選択→テキストボックス修正→再度同じお気に入りフィルタを選択ができない
2. 価格の下限が上限より大きいときにお気に入り条件を保存できてしまう
3. 価格レベルを指定なしにするとお気に入り条件の保存ができない

# 変更内容
1. 同じお気に入り条件を選択するとonChangeが起動しないのが原因だったので、handleFilterClick()を設けてselectedFilterを空にする処理を追加。
2. 保存できないように条件文を追加
3. 未対応