### PR TITLE
お気に入り画面の追加

### DIFF
--- a/nakajimap/src/App.tsx
+++ b/nakajimap/src/App.tsx
@@ -2,24 +2,26 @@ import React from "react"
 import Home from "./pages/Home"
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom"
 import { Auth } from "./pages/Auth"
-import { AuthProvider } from './AuthContext'
+import { AuthProvider } from "./AuthContext"
+import Favorite from "./pages/Favorite"
 import FavoriteCondition from "./pages/FavoriteCondition"
 import Layout from "./components/Layout"
 
 const App: React.FC = () => {
   return (
-      <Router>
-        <Layout>
-          <AuthProvider>
-            <Routes>
-              <Route path="/auth" element={<Auth />} />
-              <Route path="/home" element={<Home />} />
-              <Route path="/favorite_condition" element={<FavoriteCondition />} />
-              <Route path="/" element={<Auth />} />
-            </Routes>
-          </AuthProvider>
-        </Layout>
-      </Router>
+    <Router>
+      <Layout>
+        <AuthProvider>
+          <Routes>
+            <Route path="/auth" element={<Auth />} />
+            <Route path="/home" element={<Home />} />
+            <Route path="/favorite_condition" element={<FavoriteCondition />} />
+            <Route path="/favorite" element={<Favorite />} />
+            <Route path="/" element={<Auth />} />
+          </Routes>
+        </AuthProvider>
+      </Layout>
+    </Router>
   )
 }
 

--- a/nakajimap/src/components/Filter.tsx
+++ b/nakajimap/src/components/Filter.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react"
 import { Box, TextField, Typography, Button, MenuItem, Select } from "@mui/material"
 import { SelectChangeEvent } from "@mui/material/Select"
-import { addDoc, collection, getDocs } from "firebase/firestore"
+import { addDoc, collection, getDocs, query, where } from "firebase/firestore"
 import { db } from "../firebase"
 import { useLocation } from "react-router-dom"
 import { searchNearbyRestaurants } from "../functions/Search"
@@ -113,7 +113,7 @@ const RestaurantFilter: React.FC<FilterProps> = ({ setResults }) => {
             reviewCount,
             rating,
             minBudget,
-            maxBudget            
+            maxBudget
           )
           console.log(results) // 検索結果を表示するためのログ
           setResults(results) // 親コンポーネントの状態を更新
@@ -156,7 +156,8 @@ const RestaurantFilter: React.FC<FilterProps> = ({ setResults }) => {
   const fetchSavedFilters = async () => {
     if (!currentUser) return
     try {
-      const querySnapshot = await getDocs(collection(db, "filters"))
+      const q = query(collection(db, "filters"), where("userId", "==", currentUser.uid))
+      const querySnapshot = await getDocs(q)
       const filtersList: any[] = []
       querySnapshot.forEach((doc) => {
         filtersList.push({ id: doc.id, ...doc.data() })
@@ -166,7 +167,7 @@ const RestaurantFilter: React.FC<FilterProps> = ({ setResults }) => {
       if (error instanceof Error) {
         console.error("Error fetching filters: ", error.message)
       } else {
-        console.error("An unknown error occurred while fetching filters")        
+        console.error("An unknown error occurred while fetching filters")
       }
     }
   }

--- a/nakajimap/src/components/Navbar.tsx
+++ b/nakajimap/src/components/Navbar.tsx
@@ -7,16 +7,16 @@ const Navbar: React.FC = () => {
   const navigate = useNavigate()
   const [currentUser, setCurrentUser] = useState<null | object>(null)
 
-    useEffect(() => {
-      const unsubscribe = auth.onAuthStateChanged((user) => {
-        if (user) {
-          setCurrentUser(user)
-        } else {
-          navigate("/auth")
-        }
-      })
-      return () => unsubscribe()
-    }, [navigate])
+  useEffect(() => {
+    const unsubscribe = auth.onAuthStateChanged((user) => {
+      if (user) {
+        setCurrentUser(user)
+      } else {
+        navigate("/auth")
+      }
+    })
+    return () => unsubscribe()
+  }, [navigate])
 
   return (
     <AppBar position="static">
@@ -30,7 +30,11 @@ const Navbar: React.FC = () => {
         <Button color="inherit" onClick={() => navigate("/favorite_condition")}>
           お気に入り条件
         </Button>
-        <Button color="inherit"
+        <Button color="inherit" onClick={() => navigate("/favorite")}>
+          お気に入り
+        </Button>
+        <Button
+          color="inherit"
           onClick={async () => {
             try {
               await auth.signOut()

--- a/nakajimap/src/components/Table.tsx
+++ b/nakajimap/src/components/Table.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react"
+import { collection, doc, addDoc, getDoc, getDocs, deleteDoc, query, where } from "firebase/firestore"
 import { styled } from "@mui/material/styles"
 import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder"
 import BookmarkIcon from "@mui/icons-material/Bookmark"
@@ -11,14 +12,12 @@ import TableContainer from "@mui/material/TableContainer"
 import TableHead from "@mui/material/TableHead"
 import TableRow from "@mui/material/TableRow"
 import TableSortLabel from "@mui/material/TableSortLabel"
+import { db } from "../firebase"
+import { useAuth } from "../AuthContext"
 
 interface TableProps {
   results: any[]
   onShopClick: (placeId: string) => void
-}
-
-function createData(star: number, n_review: number, shop: string, bookmark: boolean, placeId: string) {
-  return { star, n_review, shop, bookmark, placeId }
 }
 
 const ScrollableTableCell = styled(TableCell)({
@@ -28,16 +27,49 @@ const ScrollableTableCell = styled(TableCell)({
 })
 
 const SearchResult: React.FC<TableProps> = ({ results, onShopClick }) => {
-  const [rows, setRows] = useState(results)
+  const { currentUser } = useAuth()
+
+  const [rows, setRows] = useState<any[]>([])
   const [order, setOrder] = useState<"desc" | null>(null)
   const [orderBy, setOrderBy] = useState<string | null>(null)
 
+  async function checkBookmark(place_id: string, userId: string) {
+    const q = query(collection(db, "favorite"), where("place_id", "==", place_id), where("userId", "==", userId))
+    const querySnapshot = await getDocs(q)
+    if (querySnapshot.empty) {
+      return false
+    }
+
+    const doc = querySnapshot.docs[0]
+    console.log(`Document found: ${doc.id}`, doc.data())
+
+    // Bookmarkフィールドの存在と値を確認
+    return doc.data().bookmark === true
+  }
+
   useEffect(() => {
-    const newRows = results.map((result) =>
-      createData(result.rating, result.user_ratings_total, result.name, false, result.place_id)
-    )
-    setRows(newRows)
-  }, [results])
+    async function fetchData() {
+      if (!currentUser) return
+
+      const newRows = await Promise.all(
+        results.map(async (result) => {
+          const bookmark = await checkBookmark(result.place_id, currentUser.uid)
+          return {
+            place_id: result.place_id,
+            geometry: result.geometry,
+            shop: result.name,
+            vicinity: result.vicinity,
+            star: result.rating,
+            n_review: result.user_ratings_total,
+            business_status: result.business_status,
+            bookmark: bookmark,
+          }
+        })
+      )
+      setRows(newRows)
+    }
+    fetchData()
+  }, [results, currentUser])
 
   const handleSortRequest = (property: string) => {
     if (orderBy === property && order === "desc") {
@@ -49,8 +81,55 @@ const SearchResult: React.FC<TableProps> = ({ results, onShopClick }) => {
     }
   }
 
-  const handleBookmarkChange = (shop: string) => {
-    setRows((prevRows) => prevRows.map((row) => (row.shop === shop ? { ...row, bookmark: !row.bookmark } : row)))
+  const handleBookmarkChange = async (row: any) => {
+    const updatedRow = {
+      ...row,
+      bookmark: !row.bookmark,
+    }
+
+    setRows((prevRows) => prevRows.map((r) => (r.shop === row.shop ? updatedRow : r)))
+
+    if (currentUser) {
+      const { place_id, geometry, shop, vicinity, star, n_review, business_status, bookmark } = updatedRow
+      const resultData = {
+        userId: currentUser.uid,
+        place_id,
+        geometry: {
+          location: {
+            lat: typeof geometry?.location?.lat === "function" ? geometry.location.lat() : geometry?.location?.lat,
+            lng: typeof geometry?.location?.lng === "function" ? geometry.location.lng() : geometry?.location?.lng,
+          },
+        },
+        shop,
+        vicinity,
+        star,
+        n_review,
+        business_status,
+        bookmark,
+      }
+
+      try {
+        const q = query(
+          collection(db, "favorite"),
+          where("userId", "==", currentUser.uid),
+          where("place_id", "==", place_id)
+        )
+        const querySnapshot = await getDocs(q)
+
+        if (!querySnapshot.empty) {
+          // 既にお気に入りに登録されている場合
+          const docId = querySnapshot.docs[0].id
+          await deleteDoc(doc(db, "favorite", docId))
+          setRows((prevRows) => prevRows.map((r) => (r.shop === row.shop ? { ...r, bookmark: false } : r)))
+        } else {
+          // お気に入りに登録されていない場合
+          await addDoc(collection(db, "favorite"), resultData)
+          setRows((prevRows) => prevRows.map((r) => (r.shop === row.shop ? { ...r, bookmark: true } : r)))
+        }
+      } catch (error) {
+        console.error("Error writing document: ", error)
+      }
+    }
   }
 
   const sortedRows = order
@@ -106,16 +185,14 @@ const SearchResult: React.FC<TableProps> = ({ results, onShopClick }) => {
               </TableCell>
               <TableCell align="left">{row.n_review}</TableCell>
               <ScrollableTableCell align="left" onClick={() => onShopClick(row.placeId)}>
-                <span style={{ color: 'blue', textDecoration: 'underline', cursor: 'pointer' }}>
-                  {row.shop}
-                </span>
+                <span style={{ color: "blue", textDecoration: "underline", cursor: "pointer" }}>{row.shop}</span>
               </ScrollableTableCell>
               <TableCell align="left">
                 <Checkbox
                   icon={<BookmarkBorderIcon />}
                   checkedIcon={<BookmarkIcon />}
                   checked={row.bookmark}
-                  onChange={() => handleBookmarkChange(row.shop)}
+                  onChange={() => handleBookmarkChange(row)}
                 />
               </TableCell>
             </TableRow>

--- a/nakajimap/src/functions/Search.ts
+++ b/nakajimap/src/functions/Search.ts
@@ -5,7 +5,7 @@ export const searchNearbyRestaurants = (
   reviewCount: number,
   rating: number,
   minBudget?: number,
-  maxBudget?: number  
+  maxBudget?: number
 ): Promise<any[]> => {
   return new Promise<any[]>((resolve, reject) => {
     // mapを初期化(Map.tsxのmapオブジェクトとは別物)
@@ -15,9 +15,8 @@ export const searchNearbyRestaurants = (
     })
 
     // Geocode APIを使用して住所を座標に変換
-    const geocodeUrl = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(location)}&key=${
-      import.meta.env.VITE_GOOGLEMAP_API_KEY
-    }`
+    const geocodeUrl = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(location)}&key=${import.meta.env.VITE_GOOGLEMAP_API_KEY
+      }`
 
     fetch(geocodeUrl)
       .then((response) => response.json())


### PR DESCRIPTION
# 概要
- ホーム画面でお気に入りの登録・削除を可能にした。
- お気に入り画面を追加した。

# 変更内容
- ホーム画面
  - お気に入りフラグのクリックでお気に入りの登録・削除をできるようにした(画面上ではフラグの色が変わるのみ)
- お気に入り画面
  - お気に入りフラグのクリックでお気に入りの登録・削除をできるようにした(画面上ではフラグの色が変わるのみ)
  - マップ上にお気に入りの店舗を全て表示するようにした(表示数の上限があるかどうかは未検証)
  - テーブル上の店舗名またはマップ上のピンをクリックすると店舗情報が表示されるようにした

## 確認事項
- ホーム画面でお気に入りの登録と削除ができるかどうか。
- お気に入りに登録した店舗を検索した際に、フラグが立った状態でテーブルに表示されるか。
- お気に入り画面に遷移できるか。
- お気に入り画面でお気に入りの登録と削除ができるかどうか。
- お気に入り画面で店舗名またはマップ上のピンをクリックした際に店舗情報がすべての項目について表示されるか。

## 確認手順
1. ID: testuser@gmail.com PW: testtestでログイン
2. 検索をし、検索結果に対して、お気に入りフラグを立てる
3. 再度同じ条件で検索をしてお気に入りフラグが立ったままであることを確認する
4. ナビゲーションバーから「お気に入り」を選択し、お気に入り画面に遷移する
5. ホーム画面でフラグを立てた店舗がフラグが立った状態で表示されることを確認する
6. お気に入り画面でお気に入りフラグを消す
7. ホーム画面に戻って検索した時にフラグを消した店舗が、フラグが消えた状態で表示されることを確認する
8. 上記手順に倣って、お気に入りの登録・削除がホーム画面、お気に入り画面の両方で正しく機能するか確認する

#  課題
- 基本対処はしているが、ユーザーを変えた場合に他のユーザーのお気に入りが表示されるかどうかは未検証のため、検証してもらえるとありがたい。
- マップ上のピンの数について、表示数の上限があるかどうかは未検証のため、検証してもらえるとありがたい。
- ホーム画面、お気に入り画面のデータのデフォルトの並び順が今一つ良く分からない。☆の数順で良い気がする。