### PR TITLE
Googleログインで必ずアカウント選択できるよう修正

### DIFF
--- a/nakajimap/src/pages/Auth.tsx
+++ b/nakajimap/src/pages/Auth.tsx
@@ -68,10 +68,12 @@ export const Auth: React.FC = () => {
 
   const handleGoogleSignIn = async () => {
     const provider = new GoogleAuthProvider()
+    provider.setCustomParameters({
+      prompt: "select_account", // アカウント選択画面を必ず表示
+    })
     try {
       await signInWithPopup(auth, provider)
       console.log("Google sign in succeeded!")
-      navigate("/home")
     } catch (error) {
       console.error("Google sign in failed!", error)
       alert("Google sign in failed!")


### PR DESCRIPTION
# 概要
- ブラウザでGoogleにすでにログインしている場合に、Googleでログインボタンを押下すると、ポップアップウィンドウがアカウント選択画面に遷移せず自動的にログインされるようになっていた。わかりづらいので、どんな場合でも必ずアカウント選択画面に遷移するように設定した。

# 変更内容
- handleGoogleSignIn()を修正

## 確認事項
- ブラウザでGoogleにログインしている状態でアプリを起動し、「Googleでログイン」すると、アカウントを選択してログインできることを確認する。

## 確認手順
1. 元のコードで上記確認事項を実施し、アカウント選択ができず自動的にログインされてしまうことを確認する。
2. 今回pushしたコードで上記確認事項を実施し、アカウント選択ができてログインできることを確認する。